### PR TITLE
Optimize object type by skipping check unexpected field error

### DIFF
--- a/lib/mighty_json/type.rb
+++ b/lib/mighty_json/type.rb
@@ -142,16 +142,16 @@ module MightyJSON
         keys = @fields.keys.map(&:inspect)
 
         result = var.next
+
         <<~END
           begin
             raise Error.new(path: #{path}, type: #{self.to_s.inspect}, value: object) unless #{v}.is_a?(Hash)
+            #{v}.each do |key, value|
+              next if #{keys.map{|key| "#{key} == key"}.join('||')}
+              raise UnexpectedFieldError.new(path: #{path.inspect} + [key], value: #{v}) # TOOD: optimize path
+            end
 
             {}.tap do |#{result}|
-              #{v}.each do |key, value|
-                next if #{keys.map{|key| "#{key} == key"}.join('||')}
-                raise UnexpectedFieldError.new(path: #{path.inspect} + [key], value: #{v}) # TOOD: optimize path
-              end
-
               #{
                 @fields.map do |key, type|
                   new_var = var.next

--- a/lib/mighty_json/type.rb
+++ b/lib/mighty_json/type.rb
@@ -13,6 +13,8 @@ module MightyJSON
     end
 
     class Base
+      attr_reader :type
+
       def initialize(type)
         @type = type
       end
@@ -142,13 +144,17 @@ module MightyJSON
         keys = @fields.keys.map(&:inspect)
 
         result = var.next
+        is_fixed = @fields.values.none?{|type| type.is_a?(Optional) || (type.is_a?(Base) && type.type == :ignored)}
 
         <<~END
           begin
             raise Error.new(path: #{path}, type: #{self.to_s.inspect}, value: object) unless #{v}.is_a?(Hash)
-            #{v}.each do |key, value|
-              next if #{keys.map{|key| "#{key} == key"}.join('||')}
-              raise UnexpectedFieldError.new(path: #{path.inspect} + [key], value: #{v}) # TOOD: optimize path
+
+            if #{!is_fixed} || #{@fields.size} != #{v}.size
+              #{v}.each do |key, value|
+                next if #{keys.map{|key| "#{key} == key"}.join('||')}
+                raise UnexpectedFieldError.new(path: #{path.inspect} + [key], value: #{v}) # TOOD: optimize path
+              end
             end
 
             {}.tap do |#{result}|

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -8,6 +8,7 @@ class TestObject < Minitest::Test
 
     assert{s.test.coerce(a: 1, b: 'foo') == {a: 1, b: 'foo'}}
     assert_raises(MightyJSON::Error){s.test.coerce(a: 'foo', b: 1)}
+    assert_raises(MightyJSON::Error){s.test.coerce(a: 1, c: 'bar')}
   end
 
   def test_object_with_ignored
@@ -31,5 +32,15 @@ class TestObject < Minitest::Test
     assert{s.test.coerce({b: 'foo'}) == {b: 'foo'}}
     assert{s.test.coerce({a: nil, b: 'foo'}) == {a: nil, b: 'foo'}}
     assert_raises(MightyJSON::Error){s.test.coerce(a: 'foo')}
+  end
+
+  def test_nested_object
+    s = MightyJSON.new do
+      let :test, object(a: numeric, b: object(foo: string, bar: number))
+    end
+
+    assert{s.test.coerce(a: 1, b: {foo: 'hoge', bar: 1}) == {a: 1, b: {foo: 'hoge', bar: 1}}}
+    ex = assert_raises(MightyJSON::UnexpectedFieldError){s.test.coerce(a: 1, b: {foo: 'hoge', bar: 1, baz: 2})}
+    assert{ex.message == 'Unexpected field of b.baz ({:foo=>"hoge", :bar=>1, :baz=>2})'}
   end
 end


### PR DESCRIPTION
It can skip checking unexpected filed error of object type if the following conditions are satisfied.

- Fields are not an optional type or ignored type.
- Field's size equals value size

benchmark by large data

| /   | before             | after              |
| --- | ------------------ | ------------------ |
| 1st | 3.6025956390076317 | 2.9032996260211803 |
| 2nd | 3.5137637740117498 | 2.8791273729875684 |
| 3rd | 3.5728156230179593 | 2.9158440880128182 |
| 4th | 3.5317482670070603 | 2.92016755300574   |
| 5th | 3.5569444579887204 | 2.8621528139919974 |
| avg | 3.5555735522066243 | 2.896118290803861  |

By this change, MightyJSON is faster around 1.2x.
